### PR TITLE
WIRE-194: Adding support for `enum` as `typedef`. Update CMake logic …

### DIFF
--- a/cmake/modules/AddLLD.cmake
+++ b/cmake/modules/AddLLD.cmake
@@ -10,8 +10,14 @@ macro(add_lld_library name)
   llvm_add_library(${name} ${ARG_ENABLE_SHARED} ${ARG_UNPARSED_ARGUMENTS})
   set_target_properties(${name} PROPERTIES FOLDER "lld libraries")
   target_compile_options(${name} PUBLIC -fexceptions -Wno-reorder -Wno-sign-compare -Wno-unused-local-typedefs -fno-omit-frame-pointer)
-  target_include_directories(${name} PUBLIC ${CMAKE_SOURCE_DIR}/../tools/jsoncons/include)
-  target_include_directories(${name} PUBLIC ${CMAKE_SOURCE_DIR}/../tools/include)
+  
+  if(NOT CDT_TOOL_DIR OR NOT IS_DIRECTORY ${CDT_TOOL_DIR})
+    get_filename_component(CDT_TOOL_DIR "${CMAKE_SOURCE_DIR}/../tools" ABSOLUTE)
+    message(NOTICE "CDT_TOOL_DIR is not set or invalid, defaulting to ${CDT_TOOL_DIR}")
+  endif()
+
+  target_include_directories(${name} PUBLIC ${CDT_TOOL_DIR}/jsoncons/include)
+  target_include_directories(${name} PUBLIC ${CDT_TOOL_DIR}/include)
 
   if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
     if(${name} IN_LIST LLVM_DISTRIBUTION_COMPONENTS OR


### PR DESCRIPTION
WIRE-194: Adding support for `enum` as `typedef`. Update CMake logic for LLD and adjust .gitignore

Refactored `AddLLD.cmake` to dynamically set `CDT_TOOL_DIR` if unset or invalid, improving configurability. Updated `.gitignore` to exclude `.cmake_targets.txt` for cleaner repo management.